### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/cmd/baton-verkada/main.go
+++ b/cmd/baton-verkada/main.go
@@ -54,6 +54,7 @@ func getConnector(ctx context.Context, cc *cfg.Verkada) (types.ConnectorServer, 
 		ctx,
 		cc.ApiKey,
 		cc.Region,
+		cc.BaseUrl,
 	)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -6,6 +6,7 @@ import "reflect"
 type Verkada struct {
 	ApiKey string `mapstructure:"api-key"`
 	Region string `mapstructure:"region"`
+	BaseUrl string `mapstructure:"base-url"`
 }
 
 func (c *Verkada) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,6 +24,7 @@ var RegionField = field.SelectField(
 var BaseURLField = field.StringField(
 	"base-url",
 	field.WithDescription("Override the Verkada API URL (for testing)"),
+	field.WithHidden(true),
 )
 
 //go:generate go run ./gen

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,11 +21,17 @@ var RegionField = field.SelectField(
 	field.WithDefaultValue("US"),
 )
 
+var BaseURLField = field.StringField(
+	"base-url",
+	field.WithDescription("Override the Verkada API URL (for testing)"),
+)
+
 //go:generate go run ./gen
 var Config = field.NewConfiguration(
 	[]field.SchemaField{
 		ApiKeyField,
 		RegionField,
+		BaseURLField,
 	},
 )
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,6 +25,7 @@ var BaseURLField = field.StringField(
 	"base-url",
 	field.WithDescription("Override the Verkada API URL (for testing)"),
 	field.WithHidden(true),
+	field.WithExportTarget(field.ExportTargetCLIOnly),
 )
 
 //go:generate go run ./gen

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -43,13 +43,13 @@ func (v *Verkada) Validate(ctx context.Context) (annotations.Annotations, error)
 }
 
 // New returns a new instance of the connector.
-func New(ctx context.Context, apiKey, region string) (*Verkada, error) {
+func New(ctx context.Context, apiKey, region, baseURL string) (*Verkada, error) {
 	httpClient, err := uhttp.NewClient(ctx, uhttp.WithLogger(true, ctxzap.Extract(ctx)))
 	if err != nil {
 		return nil, err
 	}
 
 	return &Verkada{
-		client: verkada.NewClient(httpClient, apiKey, region),
+		client: verkada.NewClient(httpClient, apiKey, region, baseURL),
 	}, nil
 }

--- a/pkg/verkada/client.go
+++ b/pkg/verkada/client.go
@@ -12,8 +12,8 @@ import (
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 )
 
-const BaseUrlUS = "https://api.verkada.com"
-const BaseUrlEU = "https://api.eu.verkada.com"
+const DefaultBaseURLUS = "https://api.verkada.com"
+const DefaultBaseURLEU = "https://api.eu.verkada.com"
 
 type Client struct {
 	httpClient     *http.Client
@@ -27,15 +27,17 @@ type RequestBody struct {
 	UserID string `json:"user_id"`
 }
 
-func NewClient(httpClient *http.Client, apiKey, region string) *Client {
-	baseUrl := BaseUrlUS
-	if region != "US" {
-		baseUrl = BaseUrlEU
+func NewClient(httpClient *http.Client, apiKey, region, baseURL string) *Client {
+	if baseURL == "" {
+		baseURL = DefaultBaseURLUS
+		if region != "US" {
+			baseURL = DefaultBaseURLEU
+		}
 	}
 	return &Client{
 		httpClient:     httpClient,
 		apiKey:         apiKey,
-		baseURL:        baseUrl,
+		baseURL:        baseURL,
 		tokenCreatedAt: time.Time{},
 		token:          "",
 	}

--- a/pkg/verkada/client.go
+++ b/pkg/verkada/client.go
@@ -159,7 +159,7 @@ func (c *Client) doRequest(ctx context.Context, method, path string, res interfa
 	req.Header.Add("accept", "application/json")
 	req.Header.Add("content-type", "application/json")
 	req.Header.Add("x-verkada-auth", c.token)
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.httpClient.Do(req) //nolint:gosec,nolintlint // G704: URL constructed from trusted config
 	if err != nil {
 		return err
 	}
@@ -197,7 +197,7 @@ func (c *Client) getToken(ctx context.Context) (*TokenResponse, error) {
 	req.Header.Add("accept", "application/json")
 	req.Header.Add("content-type", "application/json")
 	req.Header.Add("x-api-key", c.apiKey)
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.httpClient.Do(req) //nolint:gosec,nolintlint // G704: URL constructed from trusted config
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-verkada/main.go,pkg/config/conf.gen.go,pkg/config/config.go,pkg/connector/connector.go,pkg/verkada/client.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-verkada --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.