### PR TITLE
docs: clarify Access Control endpoint required for API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Check out [Baton](https://github.com/conductorone/baton) to learn more about the
 
 - Access to the Verkada Command platform.
 - API key. Only Organization Admins can create API keys. To create a new API key, go to Organization settings -> Verkada API -> New API Key
+- When creating the API key, under endpoint access, enable the **Access Control** endpoint - this connector only calls `/access/v1/*` endpoints and does not need access to Core, Cameras, Alarms, Video, or any other endpoint category.
 - Set the API key permissions to 'read only' if your want to just fetch the data about users and access. If you want provissioning support (adding and removing users from access groups) set the permissions to 'read/write'.
 
 ## brew

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Check out [Baton](https://github.com/conductorone/baton) to learn more about the
 
 - Access to the Verkada Command platform.
 - API key. Only Organization Admins can create API keys. To create a new API key, go to Organization settings -> Verkada API -> New API Key
-- When creating the API key, under endpoint access, enable the **Access Control** endpoint - this connector only calls `/access/v1/*` endpoints and does not need access to Core, Cameras, Alarms, Video, or any other endpoint category.
+- When creating the API key, under endpoint access, enable the **Access Control** endpoint.
 - Set the API key permissions to 'read only' if your want to just fetch the data about users and access. If you want provissioning support (adding and removing users from access groups) set the permissions to 'read/write'.
 
 ## brew


### PR DESCRIPTION
## Summary
- The connector only calls `/access/v1/*` endpoints (access users, access groups), so document that the **Access Control** endpoint category must be enabled when creating the Verkada API key.

## Test plan
- [x] Docs-only change; no functional impact.